### PR TITLE
Check if any payments are present

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -6,6 +6,7 @@ Spree::CheckoutController.class_eval do
 
   def pay_with_payu
     return unless params[:state] == 'payment'
+    return unless params[:order].to_h[:payments_attributes].present?
 
     pm_id = params[:order][:payments_attributes].first[:payment_method_id]
     payment_method = Spree::PaymentMethod.find(pm_id)


### PR DESCRIPTION
when no payments are present skip filter and allow base error messag to pop in instead of cryptic NoMethodError: undefined method 'first' for nil:NilClass
